### PR TITLE
31: Make CSV columns conditionally required

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dev = [
   "pytest",
   "pytest-clarity",
   "pytest-mock",
-  "ruff"
+  "ruff",
 ]
 
 [project.scripts]

--- a/src/sweeper/draw.py
+++ b/src/sweeper/draw.py
@@ -14,6 +14,7 @@ from sweeper.io import (
     write_result_to_csv,
     write_result_to_json,
 )
+from sweeper.option_required_if import OptionRequiredIf
 
 
 logger = logging.getLogger(__name__)
@@ -179,6 +180,9 @@ sweeper draw --entrants entrants.txt --picks picks.txt --draw-order picks
 )
 @click.option(
     "--entrants-column",
+    cls=OptionRequiredIf,
+    required_if_option="entrants",
+    required_if_value=".csv",
     type=str,
     help="Column name or index to use from entrants file, if a CSV file",
 )

--- a/src/sweeper/draw.py
+++ b/src/sweeper/draw.py
@@ -183,6 +183,7 @@ sweeper draw --entrants entrants.txt --picks picks.txt --draw-order picks
     cls=OptionRequiredIf,
     required_if_option="entrants",
     required_if_value=".csv",
+    required_if_value_transform=lambda x: x.suffix,
     type=str,
     help="Column name or index to use from entrants file, if a CSV file",
 )
@@ -194,6 +195,10 @@ sweeper draw --entrants entrants.txt --picks picks.txt --draw-order picks
 )
 @click.option(
     "--picks-column",
+    cls=OptionRequiredIf,
+    required_if_option="picks",
+    required_if_value=".csv",
+    required_if_value_transform=lambda x: x.suffix,
     type=str,
     help="Column name or index to use from picks file, if a CSV file",
 )

--- a/src/sweeper/draw.py
+++ b/src/sweeper/draw.py
@@ -10,6 +10,7 @@ from prettytable import PrettyTable
 
 from sweeper.io import (
     get_lines_from_file,
+    get_path_suffix,
     load_csv,
     write_result_to_csv,
     write_result_to_json,
@@ -183,9 +184,9 @@ sweeper draw --entrants entrants.txt --picks picks.txt --draw-order picks
     cls=OptionRequiredIf,
     required_if_option="entrants",
     required_if_value=".csv",
-    required_if_value_transform=lambda x: x.suffix,
+    required_if_value_transform=get_path_suffix,
     type=str,
-    help="Column name or index to use from entrants file, if a CSV file",
+    help="Column name or index to use from entrants file, if a CSV file.",
 )
 @click.option(
     "--picks",
@@ -198,9 +199,9 @@ sweeper draw --entrants entrants.txt --picks picks.txt --draw-order picks
     cls=OptionRequiredIf,
     required_if_option="picks",
     required_if_value=".csv",
-    required_if_value_transform=lambda x: x.suffix,
+    required_if_value_transform=get_path_suffix,
     type=str,
-    help="Column name or index to use from picks file, if a CSV file",
+    help="Column name or index to use from picks file, if a CSV file.",
 )
 @click.option(
     "--draw-order",

--- a/src/sweeper/io.py
+++ b/src/sweeper/io.py
@@ -96,3 +96,11 @@ def write_result_to_json(result: dict, path: Path) -> None:
     """
     with open(path, "w") as jsonfile:
         json.dump(result, jsonfile, indent=4)
+
+
+def get_path_suffix(path: Path) -> str:
+    """
+    Implemented as a named function to display more useful help text for
+    OptionRequiredIf options - a lambda function only displays as <lambda>.
+    """
+    return path.suffix

--- a/src/sweeper/option_required_if.py
+++ b/src/sweeper/option_required_if.py
@@ -1,0 +1,65 @@
+import click
+
+
+class OptionRequiredIf(click.Option):
+    """
+    Custom Click option that is required if another option has a specific value.
+
+    Credit:
+    - https://gist.github.com/drorata/1fa68b477d94aea5d37e87aa56e09295
+    - https://stackoverflow.com/a/46451650/671013
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        """
+        `required_if_option`: the name of the other option that makes this
+        option required
+        `required_if_value`: the value of the other option that makes this
+        option required
+        `required_if_value_func`: an optional function that takes the other
+        option's value and returns a value to compare against.
+        e.g. to make --abbrev required if --name is more than 5 characters:
+            @click.option(
+                "--abbrev",
+                cls=OptionRequiredIf,
+                required_if_option="name",
+                required_if_value=".csv",
+                required_if_option_op=lambda v: v.suffix,
+            )
+        """
+        self.required_if_option = kwargs.pop("required_if_option")
+        self.required_if_value = kwargs.pop("required_if_value")
+        self.required_if_option_op = kwargs.pop("required_if_option_op", None)
+
+        assert self.required_if_option, "'required_if_option' parameter required"
+        assert self.required_if_value, "'required_if_value' parameter required"
+
+        if self.required_if_option_op:
+            kwargs["help"] = (
+                f"{kwargs.get('help', '')} Option required if {self.required_if_option_op.__name__}(--{self.required_if_option}) is '{self.required_if_value}'"
+            ).strip()
+        else:
+            kwargs["help"] = (
+                f"{kwargs.get('help', '')} Option required if --{self.required_if_option} is '{self.required_if_value}'"
+            ).strip()
+        super(OptionRequiredIf, self).__init__(*args, **kwargs)
+
+    def process_value(self, ctx, value) -> click.Option:
+        value = super(OptionRequiredIf, self).process_value(ctx, value)
+
+        if value is None:
+            if self.required_if_option_op:
+                value_to_check = self.required_if_option_op(
+                    ctx.params[self.required_if_option]
+                )
+                msg = f"Required if {self.required_if_option_op.__name__}(--{self.required_if_option})={self.required_if_value}"
+            else:
+                value_to_check = ctx.params[self.required_if_option]
+                msg = (
+                    f"Required if --{self.required_if_option}={self.required_if_value}"
+                )
+
+            if value_to_check == self.required_if_value:
+                raise click.MissingParameter(ctx=ctx, param=self, message=msg)
+
+        return value

--- a/src/sweeper/option_required_if.py
+++ b/src/sweeper/option_required_if.py
@@ -1,3 +1,6 @@
+from copy import deepcopy
+from typing import Any
+
 import click
 
 
@@ -14,29 +17,54 @@ class OptionRequiredIf(click.Option):
         """
         `required_if_option`: the name of the other option that makes this
         option required
-        `required_if_value`: the value of the other option that makes this
-        option required
-        `required_if_value_func`: an optional function that takes the other
-        option's value and returns a value to compare against.
-        e.g. to make --abbrev required if --name is more than 5 characters:
+        `required_if_value`: [optional] the value of the other option that makes this
+        option required. If not passed, `required_if_option` just needs to be passed to
+        make this option required (i.e. regardless of its value).
+        `required_if_value_transform`: [optiona] a function to apply to the other
+        option's value, returning a value to compare against.
+        `required_if_value_check`: [optiona] a function to apply to the other
+        option's value, asserting True or False. True means this option is required.
+
+        Examples:
+
+        1. Make --abbrev required if --name is more than 5 characters:
             @click.option(
                 "--abbrev",
                 cls=OptionRequiredIf,
                 required_if_option="name",
-                required_if_value=".csv",
-                required_if_option_op=lambda v: v.suffix,
+                required_if_value_check=lambda x: len(x) > 5,
+            )
+
+        2. Make --abbrev required if the value of --name, when transformed to
+           UPPERCASE, is "JOHN":
+            @click.option(
+                "--abbrev",
+                cls=OptionRequiredIf,
+                required_if_option="name",
+                required_if_value="JOHN",
+                required_if_value_transform=lambda x: x.upper(),
             )
         """
         self.required_if_option = kwargs.pop("required_if_option")
-        self.required_if_value = kwargs.pop("required_if_value")
-        self.required_if_option_op = kwargs.pop("required_if_option_op", None)
+        self.required_if_value = kwargs.pop("required_if_value", None)
+        self.required_if_value_transform = kwargs.pop(
+            "required_if_value_transform", None
+        )
+        self.required_if_value_check = kwargs.pop("required_if_value_check", None)
 
         assert self.required_if_option, "'required_if_option' parameter required"
-        assert self.required_if_value, "'required_if_value' parameter required"
+        if self.required_if_value_transform:
+            assert (
+                self.required_if_value
+            ), "'required_if_value' parameter required if using 'required_if_value_transform'"
 
-        if self.required_if_option_op:
+        if self.required_if_value_transform:
             kwargs["help"] = (
-                f"{kwargs.get('help', '')} Option required if {self.required_if_option_op.__name__}(--{self.required_if_option}) is '{self.required_if_value}'"
+                f"{kwargs.get('help', '')} Option required if {self.required_if_value_transform.__name__}(--{self.required_if_option}) is '{self.required_if_value}'"
+            ).strip()
+        elif self.required_if_value_check:
+            kwargs["help"] = (
+                f"{kwargs.get('help', '')} Option required if {self.required_if_value_check.__name__}(--{self.required_if_option}) is True"
             ).strip()
         else:
             kwargs["help"] = (
@@ -44,22 +72,77 @@ class OptionRequiredIf(click.Option):
             ).strip()
         super(OptionRequiredIf, self).__init__(*args, **kwargs)
 
+    def should_be_required(
+        self, required_if_option: str, other_option_value: Any
+    ) -> bool:
+        """
+        Determine if this option (self) should be required based on the other
+        option's value.
+
+        Logic as follows:
+            1. If there's a transform, do that first
+            2. If there's a check, do that and return bool
+            3. Else if there's a value to compare against, compare and return bool
+            4. If there's none of the above, return True if the option is set
+        """
+        actual_value = deepcopy(other_option_value)
+
+        if self.required_if_transform is not None:
+            actual_value = self.required_if_transform(actual_value)
+
+        if self.required_if_value_check is not None:
+            return self.required_if_value_check(actual_value)
+
+        if self.required_if_value is not None:
+            return actual_value == self.required_if_value
+
+        if required_if_option is not None:
+            return True
+
     def process_value(self, ctx, value) -> click.Option:
+        """
+        Override `process_value` to add custom required logic.
+
+        Logic to determine if this option (self) should be required based on the other
+        option's value:
+            1. If there's a transform, do that first
+            2. If there's a boolean check, do that and raise MissingParameter
+               if True
+            3. Else if there's a value to compare against, do the comparison and raise
+               MissingParameter if they match
+            4. If there's none of the above, raise MissingParameter if the option is set
+               regardless of its value
+        """
         value = super(OptionRequiredIf, self).process_value(ctx, value)
 
         if value is None:
-            if self.required_if_option_op:
-                value_to_check = self.required_if_option_op(
+            if self.required_if_value_transform is not None:
+                actual_value = self.required_if_value_transform(
                     ctx.params[self.required_if_option]
                 )
-                msg = f"Required if {self.required_if_option_op.__name__}(--{self.required_if_option})={self.required_if_value}"
-            else:
+                msg = f"Required if {self.required_if_value_transform.__name__}(--{self.required_if_option})={self.required_if_value}"
+
+                if actual_value == self.required_if_value:
+                    raise click.MissingParameter(ctx=ctx, param=self, message=msg)
+
+            elif self.required_if_value_check is not None:
+                value_to_check = ctx.params[self.required_if_option]
+                msg = f"Required if {self.required_if_value_check.__name__}(--{self.required_if_option}) is True"
+
+                value_meets_criteria = self.required_if_value_check(value_to_check)
+                if value_meets_criteria:
+                    raise click.MissingParameter(ctx=ctx, param=self, message=msg)
+
+            elif self.required_if_value is not None:
                 value_to_check = ctx.params[self.required_if_option]
                 msg = (
                     f"Required if --{self.required_if_option}={self.required_if_value}"
                 )
+                if value_to_check == self.required_if_value:
+                    raise click.MissingParameter(ctx=ctx, param=self, message=msg)
 
-            if value_to_check == self.required_if_value:
+            elif self.required_if_option is not None:
+                msg = f"Required if --{self.required_if_option} is passed"
                 raise click.MissingParameter(ctx=ctx, param=self, message=msg)
 
         return value

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -173,7 +173,7 @@ def test_draw_command_with_csv_but_no_column_raises_error(
     assert result.exit_code != 0
     assert isinstance(result.exception, SystemExit)
     assert (
-        "Missing option '--entrants-column'. Required if <lambda>(--entrants)=.csv"
+        "Missing option '--entrants-column'. Required if get_path_suffix(--entrants)=.csv"
         in result.output
     )
 

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -150,6 +151,31 @@ def test_draw_command_with_csv_columns(
 
     mock_load_csv.assert_any_call(filepath=temp_entrants_csv_file, column_index=1)
     mock_load_csv.assert_any_call(filepath=temp_picks_csv_file, column_index=1)
+
+
+def test_draw_command_with_csv_but_no_column_raises_error(
+    mocker, temp_entrants_csv_file, temp_picks_csv_file
+):
+    runner = CliRunner()
+    result = runner.invoke(
+        draw_command,
+        [
+            "--entrants",
+            temp_entrants_csv_file,
+            "--picks",
+            temp_picks_csv_file,
+            "--picks-column",
+            1,
+            "--delay",
+            0,
+        ],
+    )
+    assert result.exit_code != 0
+    assert isinstance(result.exception, SystemExit)
+    assert (
+        "Missing option '--entrants-column'. Required if <lambda>(--entrants)=.csv"
+        in result.output
+    )
 
 
 def test_draw_command_invalid_file_suffix_raises_error(temp_py_file: Path):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,6 +6,7 @@ import pytest
 
 from sweeper.io import (
     get_lines_from_file,
+    get_path_suffix,
     load_csv_rows_as_lists,
     load_csv_rows_as_dicts,
     load_csv,
@@ -153,3 +154,14 @@ def test_write_result_to_json(tmp_path: Path):
     with open(file, "r") as in_file:
         file_data = json.load(in_file)
         assert file_data == result
+
+
+def test_get_path_suffix():
+    assert get_path_suffix(Path("file.csv")) == ".csv"
+    assert get_path_suffix(Path("file.txt")) == ".txt"
+    assert get_path_suffix(Path("file")) == ""
+    assert get_path_suffix(Path("file.name.with.dots.json")) == ".json"
+    assert get_path_suffix(Path("/some/path/to/file.csv")) == ".csv"
+    assert get_path_suffix(Path("/some/path/to/file")) == ""
+    with pytest.raises(AttributeError):
+        get_path_suffix("not/a/path/object")

--- a/tests/test_option_required_if.py
+++ b/tests/test_option_required_if.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import click
+import pytest
 from click.testing import CliRunner
 
 from sweeper.option_required_if import OptionRequiredIf
@@ -36,7 +37,62 @@ def test_option_required_if():
     assert result.exit_code == 0
 
 
-def test_option_required_if_operation():
+def test_option_required_if_value_transform_missing_value():
+    """
+    Test that required_if_value must be passed if
+    required_if_value_transform is provided.
+    """
+    with pytest.raises(AssertionError):
+
+        @click.command()
+        @click.option("--name", type=click.STRING)
+        @click.option(
+            "--abbrev",
+            type=click.STRING,
+            cls=OptionRequiredIf,
+            required_if_option="name",
+            required_if_value_transform=sum,
+        )
+        def cli(name, abbrev=None):
+            click.echo(f"name:[{name}], abbrev:[{abbrev}]")
+
+
+def test_option_required_if_value_transform():
+
+    def upper_case(x: str) -> str:
+        return x.upper()
+
+    @click.command()
+    @click.option("--name", type=click.STRING)
+    @click.option(
+        "--abbrev",
+        type=click.STRING,
+        cls=OptionRequiredIf,
+        required_if_option="name",
+        required_if_value="TOM",
+        required_if_value_transform=upper_case,
+    )
+    def cli(name, abbrev=None):
+        click.echo(f"name:[{name}], abbrev:[{abbrev}]")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--name", "sam"])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--name", "tom", "--abbrev", "t"])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--name", "tom"])
+    assert result.exception
+    assert result.exit_code != 0
+    assert "Required if upper_case(--name)=TOM" in result.output
+
+
+def test_option_required_if_value_transform_lambda():
     @click.command()
     @click.option("--path", type=click.Path(exists=False))
     @click.option(
@@ -45,7 +101,7 @@ def test_option_required_if_operation():
         cls=OptionRequiredIf,
         required_if_option="path",
         required_if_value=".csv",
-        required_if_option_op=lambda x: x.suffix,
+        required_if_value_transform=lambda x: x.suffix,
     )
     def cli(path, column=None):
         click.echo(f"path:[{path}], column:[{column}]")
@@ -66,3 +122,60 @@ def test_option_required_if_operation():
     assert result.exit_code != 0
     assert "Required if <lambda>(--path)=.csv" in result.output
 
+
+def test_option_required_if_value_check():
+
+    def longer_than_5(x: str) -> bool:
+        return len(x) > 5
+
+    @click.command()
+    @click.option("--name", type=click.STRING)
+    @click.option(
+        "--abbrev",
+        type=click.STRING,
+        cls=OptionRequiredIf,
+        required_if_option="name",
+        required_if_value_check=longer_than_5,
+    )
+    def cli(name, abbrev=None):
+        click.echo(f"name:[{name}], abbrev:[{abbrev}]")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--name", "abc"])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--name", "abcdefg", "--abbrev", "ab"])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--name", "abcdefg"])
+    assert result.exception
+    assert result.exit_code != 0
+    assert "Required if longer_than_5(--name) is True" in result.output
+
+
+def test_option_required_if_no_value():
+    """
+    Test that an option is required if another option is passed, regardless of
+    its value - i.e. if only required_if_option is provided to OptionRequiredIf.
+    """
+
+    @click.command()
+    @click.option("--name", type=click.STRING)
+    @click.option(
+        "--abbrev",
+        type=click.STRING,
+        cls=OptionRequiredIf,
+        required_if_option="name",
+    )
+    def cli(name, abbrev=None):
+        click.echo(f"name:[{name}], abbrev:[{abbrev}]")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--name", "abc"])
+    assert result.exception
+    assert result.exit_code != 0
+    assert "Required if --name is passed" in result.output

--- a/tests/test_option_required_if.py
+++ b/tests/test_option_required_if.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import click
+from click.testing import CliRunner
+
+from sweeper.option_required_if import OptionRequiredIf
+
+
+def test_option_required_if():
+    @click.command()
+    @click.option("--type", type=click.Choice(["json", "csv"]), default="json")
+    @click.option(
+        "--column",
+        type=click.STRING,
+        cls=OptionRequiredIf,
+        required_if_option="type",
+        required_if_value="csv",
+    )
+    def cli(type, column=None):
+        click.echo(f"type:[{type}], column:[{column}]")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--type", "json"])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--type", "csv"])
+    assert result.exception
+    assert result.exit_code != 0
+    assert "Required if --type=csv" in result.output
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--type", "csv", "--column", "a"])
+    assert not result.exception
+    assert result.exit_code == 0
+
+
+def test_option_required_if_operation():
+    @click.command()
+    @click.option("--path", type=click.Path(exists=False))
+    @click.option(
+        "--column",
+        type=click.STRING,
+        cls=OptionRequiredIf,
+        required_if_option="path",
+        required_if_value=".csv",
+        required_if_option_op=lambda x: x.suffix,
+    )
+    def cli(path, column=None):
+        click.echo(f"path:[{path}], column:[{column}]")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--path", Path("file.json")])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--path", Path("file.csv"), "--column", "a"])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--path", Path("file.csv")])
+    assert result.exception
+    assert result.exit_code != 0
+    assert "Required if <lambda>(--path)=.csv" in result.output
+


### PR DESCRIPTION
Make CSV columns required options if entrants or picks is a CSV file. Closes #31

- **Add OptionRequiredIf subclass to allow conditional required options**
- **Add optional arguments to transform and/or run a check against required_if_value**
- **Use new OptionRequiredIf arguments for CSV column name arguments**
- **Add named function get_path_suffix to improve option help messages**
